### PR TITLE
configpanel: Set LOCAL_PRIVATE_PLATFORM_APIS

### DIFF
--- a/configpanel/Android.mk
+++ b/configpanel/Android.mk
@@ -22,6 +22,7 @@ LOCAL_SRC_FILES := $(call all-java-files-under, src)
 LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PACKAGE_NAME := ConfigPanel
+LOCAL_PRIVATE_PLATFORM_APIS := true
 
 LOCAL_USE_AAPT2 := true
 


### PR DESCRIPTION
This change sets LOCAL_SDK_VERSION for all packages where
this is possible without breaking the build, and
LOCAL_PRIVATE_PLATFORM_APIS := true otherwise.

Setting one of these two will be made required soon, and this
is a change in preparation for that. Not setting LOCAL_SDK_VERSION
makes the app implicitly depend on the bootclasspath, which is
often not required. This change effectively makes depending on
private apis opt-in rather than opt-out.

Test: make relevant package
Bug: 73535841
Change-Id: I5196e8c7277ff86280782e7b479a499add2e8f9f